### PR TITLE
Debian 11 Upgrade

### DIFF
--- a/app/nextbox/appinfo/info.xml
+++ b/app/nextbox/appinfo/info.xml
@@ -12,7 +12,7 @@
     <category>tools</category>
     <bugs>https://github.com/Nitrokey/nextbox-app/issues</bugs>
     <dependencies>
-        <nextcloud min-version="12" max-version="26"/>
+        <nextcloud min-version="12" max-version="27"/>
     </dependencies>
     <navigations>
         <navigation>

--- a/app/nextbox/package.json
+++ b/app/nextbox/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "nextbox",
 	"description": "NextBox Configuration App",
-	"version": "1.0.36",
+	"version": "1.0.43",
 	"author": "Markus Meissner <meissner@nitrokey.com>",
 	"contributors": [],
 	"bugs": {

--- a/app/nextbox/src/System.vue
+++ b/app/nextbox/src/System.vue
@@ -54,6 +54,18 @@
 			</div>
 		</div>
 
+                
+		<div class="section">
+			<h2>System Debian Update</h2>
+			<div>
+				Here you can trigger the system update script manually. Updating to the newest Debian Version might be mandatory in the future to receive any updates or support.
+			</div>
+
+			<button type="button" @click="updateDebian">
+				<span class="icon icon-history" />
+				Update
+			</button>
+		</div>
 		<div class="section">
 			<h2>System Power State</h2>
 			<div>
@@ -163,7 +175,19 @@ export default {
 			this.config = res.data.data
 			this.update.nk_token = res.data.data.nk_token
 		},
-		
+
+
+		updateDebian() {
+			this.loadingButton = true
+			let url = ''
+			url = '/apps/nextbox/forward/updateDebian'
+			const res = axios.post(generateUrl(url)).catch((e) => {
+				showError('Connection failed')
+				console.error(e)
+			})
+			this.loadingButton = false
+		},
+
 		powerop(op) {
 			this.loadingButton = true
 			let url = ''

--- a/daemon/nextbox-compose/docker-compose.yml
+++ b/daemon/nextbox-compose/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: always
 
   app:
-    image: nextcloud:26.0.9-apache
+    image: nextcloud:27.1.5-apache
     entrypoint: "/bin/sh -c 'echo \"start delayed by 60secs...\" && sleep 60 && /entrypoint.sh apache2-foreground'"
     restart: always
     extra_hosts:
@@ -39,7 +39,7 @@ services:
       - redis
 
   cron:
-    image: nextcloud:26.0.9-apache
+    image: nextcloud:27.1.5-apache
     restart: always
     volumes:
       - nextcloud:/var/www/html

--- a/daemon/nextbox-compose/docker-compose.yml
+++ b/daemon/nextbox-compose/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: always
 
   app:
-    image: nextcloud:26.0.8-apache
+    image: nextcloud:26.0.9-apache
     entrypoint: "/bin/sh -c 'echo \"start delayed by 60secs...\" && sleep 60 && /entrypoint.sh apache2-foreground'"
     restart: always
     extra_hosts:
@@ -39,7 +39,7 @@ services:
       - redis
 
   cron:
-    image: nextcloud:26.0.8-apache
+    image: nextcloud:26.0.9-apache
     restart: always
     volumes:
       - nextcloud:/var/www/html
@@ -91,6 +91,4 @@ volumes:
       type: none
       o: bind
       device: /srv/letsencrypt
-
-
 

--- a/daemon/nextbox_daemon/api/generic.py
+++ b/daemon/nextbox_daemon/api/generic.py
@@ -164,6 +164,14 @@ def poweroff():
         return error("failed executing: 'poweroff'")
     return success(data={})
 
+@generic_api.route("/updateDebian", methods=["POST"])
+@requires_auth
+def updateDebian():
+    log.info("updateDebian - by /updateDebian    request")
+    cr = CommandRunner("touch /test123")
+    if cr.returncode != 0:
+        return error("failed executing: 'updateDebian'")
+    return success(data={})
 
 
 

--- a/daemon/scripts/nextbox-update-debian.sh
+++ b/daemon/scripts/nextbox-update-debian.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#first of all lets kill all docker instances
+/usr/bin/docker-compose -f docker-compose.yml down -v
+
+
 #setting locales
 
 locale-gen --purge en_US.UTF-8

--- a/daemon/scripts/nextbox-update-debian.sh
+++ b/daemon/scripts/nextbox-update-debian.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#setting locales
+
+locale-gen --purge en_US.UTF-8
+echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
+#prerequisites
+echo "executing prerequisites" &&
+
+echo "updating..." &&
+apt update &&
+apt remove apt-listchanges --assume-yes &&
+apt -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" -fuy dist-upgrade
+
+echo "cleanup" &&
+apt  clean &&
+apt -fuy  autoremove &&
+
+
+##upgrade itself
+
+echo "configure upgrade" &&
+
+export DEBIAN_FRONTEND=noninteractive &&
+export APT_LISTCHANGES_FRONTEND=none &&
+
+echo "executing buster to bullseye" &&
+sudo sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
+sed -i 's:buster/updates:bullseye-security:' /etc/apt/sources.list
+sed -i 's:buster/updates:bullseye-security:' /etc/apt/sources.list.d/*.list
+sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list.d/*.list
+sudo sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
+
+
+
+echo "upgrade..." &&
+
+apt update &&
+apt  -o Dpkg::Options::="--force-confold"  -o Dpkg::Options::="--force-confdef" -fuy upgrade &&
+apt  -o Dpkg::Options::="--force-confold"  -o Dpkg::Options::="--force-confdef" -fuy dist-upgrade
+
+echo "cleanup" &&
+apt -fuy  autoremove &&
+
+
+sed -i 's:/usr/lib/dhcpcd5/dhcpcd:/usr/sbin/dhcpcd:' /etc/systemd/system/dhcpcd.service.d/wait.conf
+
+
+#reboot
+systemctl reboot
+
+

--- a/debian/debian/changelog
+++ b/debian/debian/changelog
@@ -1,3 +1,9 @@
+%%PKG%% (1.0.41-1) focal; urgency=low
+
+  * NC 26.0.9
+
+ -- Markus Meissner (Debian) <coder@safemailbox.de>  Wed, 29 Nov 2023 13:39:51 +0100
+
 %%PKG%% (1.0.40-1) focal; urgency=low
 
   * bump NC to 26.0.8

--- a/debian/debian/changelog
+++ b/debian/debian/changelog
@@ -1,3 +1,10 @@
+%%PKG%% (1.0.40-1) focal; urgency=low
+
+  * bump NC to 26.0.8
+  * changelog, ci update include path
+
+ -- Markus Meissner (Debian) <coder@safemailbox.de>  Wed, 01 Nov 2023 00:16:52 +0100
+
 %%PKG%% (1.0.39-1) focal; urgency=low
 
   * NC 26.0.7

--- a/debian/debian/changelog
+++ b/debian/debian/changelog
@@ -1,3 +1,9 @@
+%%PKG%% (1.0.42-1) focal; urgency=low
+
+  * NC bump 27.1.5
+
+ -- Markus Meissner (Debian) <coder@safemailbox.de>  Sun, 17 Dec 2023 18:31:26 +0100
+
 %%PKG%% (1.0.41-1) focal; urgency=low
 
   * NC 26.0.9


### PR DESCRIPTION
Added an Update Button and a script to update the Nextbox underlying OS to Debian 11 with a single click.

TODO:

1.nohup.out is generated somewhere. Specify the output place.
2.maybe kill the Nextcloud docker instance the start of the update to make sure the user isnt doing anything during the update.
3. More Testing

Known Issues:
there was an issue with getting forwarded to the nextbox webpage after the update. This seems to be fixed with a jump to a newer version.
