### PR TITLE
Periodically purge old docker images

### DIFF
--- a/daemon/nextbox_daemon/jobs.py
+++ b/daemon/nextbox_daemon/jobs.py
@@ -19,6 +19,7 @@ from nextbox_daemon.proxy_tunnel import ProxyTunnel, ProxySetupError
 from nextbox_daemon.services import services
 from nextbox_daemon.shield import shield
 from nextbox_daemon.worker import BaseJob
+from nextbox_daemon.docker_control import DockerControl
 
 
 class LEDJob(BaseJob):
@@ -434,9 +435,27 @@ class ReIndexAllFilesJob(BaseJob):
             return False
 
 
+class PurgeOldDockerImagesJob(BaseJob):
+    """
+    Job to periodically purge old images using
+    DockerControl.purge_old_images
+    """
+
+    name = "PurgeOldDockerImages"
+
+    def __init__(self):
+        super().__init__(initial_interval=600)
+
+    def _run(self, cfg, board, kwargs):
+        # run once a week
+        self.interval = 604800
+        DockerControl().purge_old_images()
+
+
 ACTIVE_JOBS = [
     LEDJob, FactoryResetJob, BackupRestoreJob, EnableNextBoxAppJob,
     SelfUpdateJob, HardwareStatusUpdateJob,
     TrustedDomainsJob, RenewCertificatesJob, DynDNSUpdateJob,
-    EnableHTTPSJob, ReIndexAllFilesJob
+    EnableHTTPSJob, ReIndexAllFilesJob,
+    PurgeOldDockerImagesJob
 ]


### PR DESCRIPTION
Adds a job that periodically removes old docker images that aren't used anymore. It uses the version number to determine the oldest images and removes all but the 3 newest.

Known Issues:

How to test:

1. Setup Dev environment (https://github.com/Nitrokey/nextbox/blob/master/DEV.md)
2. SSH on to your NextBox and check if you have more than 3 nextcloud images (docker images)
3. If not, pull some older versions (docker pull nextcloud:VERSION, eg 25.0.10-apache, 9.0.56-apache)
4. Change the self.interval in jobs.py -> PurgeOldDockerImagesJob -> _run function to something small like 60 seconds
5. Check after that time that you have at most 3 images remaining of each type

fixes #70 