### PR TITLE
Debian 11 update

### DIFF
--- a/app/nextbox/src/System.vue
+++ b/app/nextbox/src/System.vue
@@ -58,10 +58,14 @@
 		<div class="section">
 			<h2>System Debian Update</h2>
 			<div>
-				Here you can trigger the system update script manually. Updating to the newest Debian Version might be mandatory in the future to receive any updates or support.
+				Here you can trigger the system update script manually. Updating to the newest Debian Version might be mandatory in the future to receive any updates or support. <br>
+				WARNING! <br>
+				Beware that this may cause problems and may break your system! Please back up any data you don't want to loose! <br>
+				Don't turn off your device until the status LED is green (not blinking!), this may take around an hour or two. Turning it off will break your system! <br>
+				You will need to confirm by pressing the button twice.
 			</div>
 
-			<button type="button" @click="updateDebian">
+			<button type="button" @click="updateDebian" ref="btnUpdateDebian">
 				<span class="icon icon-history" />
 				Update
 			</button>
@@ -104,6 +108,7 @@ import UtilsMixin from './UtilsMixin.js'
 // import AppContentDetails from '@nextcloud/vue/dist/Components/AppContentDetails'
 
 const FileDownload = require('js-file-download')
+let updateButtonPressed = false
 
 
 
@@ -179,12 +184,17 @@ export default {
 
 		updateDebian() {
 			this.loadingButton = true
-			let url = ''
-			url = '/apps/nextbox/forward/updateDebian'
-			const res = axios.post(generateUrl(url)).catch((e) => {
-				showError('Connection failed')
-				console.error(e)
-			})
+			if (!updateButtonPressed) {
+				updateButtonPressed = true
+				this.$refs.btnUpdateDebian.innerText = 'Confirm Update (Please read warnings above!)'
+			} else {
+				let url = ''
+				url = '/apps/nextbox/forward/updateDebian'
+				const res = axios.post(generateUrl(url)).catch((e) => {
+					showError('Connection failed')
+					console.error(e)
+				})
+			}
 			this.loadingButton = false
 		},
 

--- a/app/nextbox/src/System.vue
+++ b/app/nextbox/src/System.vue
@@ -55,7 +55,7 @@
 		</div>
 
                 
-		<div class="section">
+		<div class="section" v-if="canDebianUpdate">
 			<h2>System Debian Update</h2>
 			<div>
 				Here you can trigger the system update script manually. Updating to the newest Debian Version might be mandatory in the future to receive any updates or support. <br>
@@ -123,6 +123,7 @@ export default {
 		return {
 			loading: true,
 			loadingButton: true,
+			canDebianUpdate: false,
 			
 			// update-ables
 			update: {
@@ -179,6 +180,13 @@ export default {
 			})
 			this.config = res.data.data
 			this.update.nk_token = res.data.data.nk_token
+
+			try {
+				const res = await axios.get(generateUrl('/apps/nextbox/forward/debianVersion'))
+				this.canDebianUpdate = (res.data.data.version === 10)
+			} catch (e) {
+				console.error(e)
+			}
 		},
 
 

--- a/app/nextbox/src/System.vue
+++ b/app/nextbox/src/System.vue
@@ -54,6 +54,18 @@
 			</div>
 		</div>
 
+                
+		<div class="section">
+			<h2>System Debian Update</h2>
+			<div>
+				Here you can trigger the system update script manually. Updating to the newest Debian Version might be mandatory in the future to receive any updates or support.
+			</div>
+
+			<button type="button" @click="updateDebian">
+				<span class="icon icon-history" />
+				Update
+			</button>
+		</div>
 		<div class="section">
 			<h2>System Power State</h2>
 			<div>
@@ -163,7 +175,19 @@ export default {
 			this.config = res.data.data
 			this.update.nk_token = res.data.data.nk_token
 		},
-		
+
+
+		updateDebian() {
+			this.loadingButton = true
+			let url = ''
+			url = '/apps/nextbox/forward/updateDebian'
+			const res = axios.post(generateUrl(url)).catch((e) => {
+				showError('Connection failed')
+				console.error(e)
+			})
+			this.loadingButton = false
+		},
+
 		powerop(op) {
 			this.loadingButton = true
 			let url = ''

--- a/daemon/nextbox_daemon/api/generic.py
+++ b/daemon/nextbox_daemon/api/generic.py
@@ -179,7 +179,7 @@ def debianVersion():
 @requires_auth
 def updateDebian():
     log.info("updateDebian - by /updateDebian    request")
-    cr = CommandRunner("nohup /usr/bin/nextbox-update-debian.sh")
+    cr = CommandRunner("nohup /usr/bin/nextbox-update-debian.sh > /var/log/debian-update.log")
     if cr.returncode != 0:
         return error("failed executing: 'updateDebian'")
     return success(data={})

--- a/daemon/nextbox_daemon/api/generic.py
+++ b/daemon/nextbox_daemon/api/generic.py
@@ -164,6 +164,17 @@ def poweroff():
         return error("failed executing: 'poweroff'")
     return success(data={})
 
+
+@generic_api.route("/debianVersion", methods=["GET"])
+@requires_auth
+def debianVersion():
+    log.info("debianVersion - by /debianVersion request")
+    version_file = Path("/etc/debian_version")
+    with version_file.open() as fd:
+        version = fd.read()
+    return success(data={"version": int(version.split(".")[0])})
+
+
 @generic_api.route("/updateDebian", methods=["POST"])
 @requires_auth
 def updateDebian():

--- a/daemon/nextbox_daemon/api/generic.py
+++ b/daemon/nextbox_daemon/api/generic.py
@@ -168,7 +168,7 @@ def poweroff():
 @requires_auth
 def updateDebian():
     log.info("updateDebian - by /updateDebian    request")
-    cr = CommandRunner("nohup /usr/bin/nextbox-update-debian.sh &")
+    cr = CommandRunner("nohup /usr/bin/nextbox-update-debian.sh")
     if cr.returncode != 0:
         return error("failed executing: 'updateDebian'")
     return success(data={})

--- a/daemon/nextbox_daemon/api/generic.py
+++ b/daemon/nextbox_daemon/api/generic.py
@@ -164,6 +164,14 @@ def poweroff():
         return error("failed executing: 'poweroff'")
     return success(data={})
 
+@generic_api.route("/updateDebian", methods=["POST"])
+@requires_auth
+def updateDebian():
+    log.info("updateDebian - by /updateDebian    request")
+    cr = CommandRunner("touch /test123")
+    if cr.returncode != 0:
+        return error("failed executing: 'updateDebian'")
+    return success(data={})
 
 
 

--- a/daemon/nextbox_daemon/api/generic.py
+++ b/daemon/nextbox_daemon/api/generic.py
@@ -168,7 +168,7 @@ def poweroff():
 @requires_auth
 def updateDebian():
     log.info("updateDebian - by /updateDebian    request")
-    cr = CommandRunner("touch /test123")
+    cr = CommandRunner("nohup /usr/bin/nextbox-update-debian.sh &")
     if cr.returncode != 0:
         return error("failed executing: 'updateDebian'")
     return success(data={})

--- a/daemon/scripts/nextbox-update-debian.sh
+++ b/daemon/scripts/nextbox-update-debian.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+#first of all lets kill all docker instances
+/usr/bin/docker-compose -f docker-compose.yml down -v
+
+
 #setting locales
 
 locale-gen --purge en_US.UTF-8

--- a/daemon/scripts/nextbox-update-debian.sh
+++ b/daemon/scripts/nextbox-update-debian.sh
@@ -1,51 +1,49 @@
 #!/bin/bash
 
 #first of all lets kill all docker instances
-/usr/bin/docker-compose -f docker-compose.yml down -v
-
-
+systemctl stop nextbox-compose.service
 #setting locales
 
-locale-gen --purge en_US.UTF-8
+locale-gen --purge en_US.UTF-8 
 echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
 #prerequisites
-echo "executing prerequisites" &&
+echo "executing prerequisites" 
 
-echo "updating..." &&
-apt update &&
-apt remove apt-listchanges --assume-yes &&
+echo "updating..." 
+apt update 
+apt remove apt-listchanges --assume-yes 
 apt -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" -fuy dist-upgrade
 
-echo "cleanup" &&
-apt  clean &&
-apt -fuy  autoremove &&
+echo "cleanup" 
+apt  clean 
+apt -fuy  autoremove 
 
 
 ##upgrade itself
 
-echo "configure upgrade" &&
+echo "configure upgrade" 
 
-export DEBIAN_FRONTEND=noninteractive &&
-export APT_LISTCHANGES_FRONTEND=none &&
+export DEBIAN_FRONTEND=noninteractive 
+export APT_LISTCHANGES_FRONTEND=none 
 
-echo "executing buster to bullseye" &&
-sudo sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
+echo "executing buster to bullseye" 
+sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
 sed -i 's:buster/updates:bullseye-security:' /etc/apt/sources.list
 sed -i 's:buster/updates:bullseye-security:' /etc/apt/sources.list.d/*.list
-sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
-sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list.d/*.list
-sudo sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
+sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+sed -i 's/buster/bullseye/g' /etc/apt/sources.list.d/*.list
+sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
 
 
 
-echo "upgrade..." &&
+echo "upgrade..." 
 
-apt update &&
-apt  -o Dpkg::Options::="--force-confold"  -o Dpkg::Options::="--force-confdef" -fuy upgrade &&
+apt update 
+apt  -o Dpkg::Options::="--force-confold"  -o Dpkg::Options::="--force-confdef" -fuy upgrade 
 apt  -o Dpkg::Options::="--force-confold"  -o Dpkg::Options::="--force-confdef" -fuy dist-upgrade
 
-echo "cleanup" &&
-apt -fuy  autoremove &&
+echo "cleanup" 
+apt -fuy  autoremove
 
 
 sed -i 's:/usr/lib/dhcpcd5/dhcpcd:/usr/sbin/dhcpcd:' /etc/systemd/system/dhcpcd.service.d/wait.conf

--- a/daemon/scripts/nextbox-update-debian.sh
+++ b/daemon/scripts/nextbox-update-debian.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+#setting locales
+
+locale-gen --purge en_US.UTF-8
+echo -e 'LANG="en_US.UTF-8"\nLANGUAGE="en_US:en"\n' > /etc/default/locale
+#prerequisites
+echo "executing prerequisites" &&
+
+echo "updating..." &&
+apt update &&
+apt remove apt-listchanges --assume-yes &&
+apt -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" -fuy dist-upgrade
+
+echo "cleanup" &&
+apt  clean &&
+apt -fuy  autoremove &&
+
+
+##upgrade itself
+
+echo "configure upgrade" &&
+
+export DEBIAN_FRONTEND=noninteractive &&
+export APT_LISTCHANGES_FRONTEND=none &&
+
+echo "executing buster to bullseye" &&
+sudo sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
+sed -i 's:buster/updates:bullseye-security:' /etc/apt/sources.list
+sed -i 's:buster/updates:bullseye-security:' /etc/apt/sources.list.d/*.list
+sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list
+sudo sed -i 's/buster/bullseye/g' /etc/apt/sources.list.d/*.list
+sudo sed -i 's#/debian-security bullseye/updates# bullseye-security#g' /etc/apt/sources.list
+
+
+
+echo "upgrade..." &&
+
+apt update &&
+apt  -o Dpkg::Options::="--force-confold"  -o Dpkg::Options::="--force-confdef" -fuy upgrade &&
+apt  -o Dpkg::Options::="--force-confold"  -o Dpkg::Options::="--force-confdef" -fuy dist-upgrade
+
+echo "cleanup" &&
+apt -fuy  autoremove &&
+
+
+sed -i 's:/usr/lib/dhcpcd5/dhcpcd:/usr/sbin/dhcpcd:' /etc/systemd/system/dhcpcd.service.d/wait.conf
+
+
+#reboot
+systemctl reboot
+
+


### PR DESCRIPTION
Added an Update Button and a script to update the Nextbox underlying OS to Debian 11 with a single click.

TODO:

1. Test that update stdout is stored in /var/log/debian-update.log
2. More Testing

Known Issues:

How to test:

1. Setup Dev environment (https://github.com/Nitrokey/nextbox/blob/master/DEV.md)
2. arbitrary edit of app/nextbox/src/System.vue and daemon/nextbox_daemon/api/generic.py to trigger watch scripts
3. copy daemon/scripts/nextbox-update-debian.sh to /usr/bin/ manually. make sure rights are the same as other scripts
4. run the update script from the nextbox app web frontend
5. check for errors with journalctl and /var/log/debian-update.log
