### PR TITLE
app: layout fixes

### DIFF
--- a/app/nextbox/src/App.vue
+++ b/app/nextbox/src/App.vue
@@ -36,7 +36,7 @@
 			</ul>
 		</AppNavigation>
 			
-		<AppContent>
+		<AppContent class=app-content>
 			<Overview v-if="page === 'overview'" />
 			<Storage v-if="page === 'storage'" />
 			<Backup v-if="page === 'backup' || page === 'backup_exclusive'" @newPage="set_page" />
@@ -232,6 +232,10 @@ h3 {
 
 #app-navigation-vue > ul.app-navigation__list {
 	height: 30% !important
+}
+
+.app-content {
+	overflow: auto;
 }
 
 

--- a/app/nextbox/src/App.vue
+++ b/app/nextbox/src/App.vue
@@ -27,7 +27,6 @@
 					icon="icon-public"
 					@click="set_page('remote_static_dns')" />
 				<AppNavigationItem
-					v-if="isRemoteOpen"
 					:title="t('nextbox', 'HTTPS / TLS')"
 					icon="icon-password"
 					@click="set_page('tls')" />

--- a/app/nextbox/src/App.vue
+++ b/app/nextbox/src/App.vue
@@ -5,19 +5,32 @@
 				<AppNavigationItem :title="t('nextbox', 'Overview')" icon="icon-home" @click="set_page('overview')" />
 				<AppNavigationItem :title="t('nextbox', 'Storage Management')" icon="icon-category-files" @click="set_page('storage')" />
 				<AppNavigationItem :title="t('nextbox', 'Backup / Restore')" icon="icon-download" @click="set_page('backup')" />
-				<AppNavigationItem :title="t('nextbox', 'Remote Access')"
-					icon="icon-timezone"
-					:allow-collapse="false"
-					:open="isRemoteOpen"
-					@click="set_page('remote')">
-					<template>
-						<AppNavigationItem :title="t('nextbox', 'Backwards Proxy')" icon="icon-star" @click="set_page('remote_proxy')" />
-						<AppNavigationItem :title="t('nextbox', 'Guided Dynamic DNS')" icon="icon-comment" @click="set_page('remote_dyndns')" />
-						<AppNavigationItem :title="t('nextbox', 'Custom Dynamic DNS')" icon="icon-settings" @click="set_page('remote_custom_dns')" />
-						<AppNavigationItem :title="t('nextbox', 'Static Domain')" icon="icon-public" @click="set_page('remote_static_dns')" />
-						<AppNavigationItem :title="t('nextbox', 'HTTPS / TLS')" icon="icon-password" @click="set_page('tls')" />
-					</template>
-				</AppNavigationItem>
+				<AppNavigationItem :title="t('nextbox', 'Remote Access')" icon="icon-timezone" @click="set_page('remote')" />
+				<AppNavigationItem
+					v-if="isRemoteOpen"
+					:title="t('nextbox', 'Backwards Proxy')"
+					icon="icon-star"
+					@click="set_page('remote_proxy')" />
+				<AppNavigationItem
+					v-if="isRemoteOpen"
+					:title="t('nextbox', 'Guided Dynamic DNS')"
+					icon="icon-comment"
+					@click="set_page('remote_dyndns')" />
+				<AppNavigationItem
+					v-if="isRemoteOpen"
+					:title="t('nextbox', 'Custom Dynamic DNS')"
+					icon="icon-settings"
+					@click="set_page('remote_custom_dns')" />
+				<AppNavigationItem
+					v-if="isRemoteOpen"
+					:title="t('nextbox', 'Static Domain')"
+					icon="icon-public"
+					@click="set_page('remote_static_dns')" />
+				<AppNavigationItem
+					v-if="isRemoteOpen"
+					:title="t('nextbox', 'HTTPS / TLS')"
+					icon="icon-password"
+					@click="set_page('tls')" />
 				
 				<AppNavigationItem :title="t('nextbox', 'System Settings')" icon="icon-settings" @click="set_page('system')" />
 				<!-- AppNavigationItem :title="t('nextbox', 'Daemon Logs')" icon="icon-info" @click="set_page('logs')" /-->
@@ -117,7 +130,8 @@ export default {
 	methods: {
 		set_page(what) {
 			this.page = what
-			if (this.page.startsWith('remote_')) this.isRemoteOpen = true
+			if (this.page.startsWith('remote')) this.isRemoteOpen = true
+			else this.isRemoteOpen = false
 		},
 	},
 }

--- a/app/nextbox/src/TLS.vue
+++ b/app/nextbox/src/TLS.vue
@@ -3,7 +3,12 @@
 		<div class="section">
 			<h2>HTTPS / TLS Status</h2>
 			<div v-if="!dns_mode.endsWith('_done')" icon="icon-close">
-				To activate TLS encryption for your NextBox, first finish a DNS Configuration.
+				To activate TLS encryption for your NextBox, first finish a DNS Configuration under:
+				<ul>
+					<li class="remote-action" @click="$emit('newPage', 'remote')">
+						Remote Access
+					</li>
+				</ul>
 			</div>
 			<div v-else>
 				<StatusBar v-if="domain" preset="resolve_ipv4" />
@@ -346,5 +351,14 @@ export default {
 	padding: 5vh;
 }
 
+.remote-action {
+	margin-top: 10px;
+	font-size: 1.1em;
+	font-weight: bold;
+	vertical-align: middle;
+	line-height: 48px;
+	cursor: pointer;
+	width: fit-content;
+}
 
 </style>


### PR DESCRIPTION
Changes the navbar so that the remotes subsections are not gruped in a nested section, but instead be invisible until you open the main remotes section.
Adds a scrollbar to app sites that overflow the screen.

fixes #86 