### PR TITLE
Debian update button changes

### DIFF
--- a/app/nextbox/src/System.vue
+++ b/app/nextbox/src/System.vue
@@ -202,6 +202,8 @@ export default {
 					showError('Connection failed')
 					console.error(e)
 				})
+				this.$refs.btnUpdateDebian.innerText = 'Update Started! Don\'t turn off your device! This might take a few hours!'
+				this.$refs.btnUpdateDebian.disabled = true
 			}
 			this.loadingButton = false
 		},

--- a/app/nextbox/src/System.vue
+++ b/app/nextbox/src/System.vue
@@ -61,7 +61,8 @@
 				Here you can trigger the system update script manually. Updating to the newest Debian Version might be mandatory in the future to receive any updates or support. <br>
 				WARNING! <br>
 				Beware that this may cause problems and may break your system! Please back up any data you don't want to loose! <br>
-				Don't turn off your device until the status LED is green (not blinking!), this may take around an hour or two. Turning it off will break your system! <br>
+				Don't turn off your device until the status LED is green (not blinking!), this may take a few hours depending on your internet connection. <br>
+				Turning the NextBox off while updating will break your system! <br>
 				You will need to confirm by pressing the button twice.
 			</div>
 


### PR DESCRIPTION
Disable update button on second press (when update starts) and change its text.
Change warning text to not limit amount of time needed.