### PR TITLE
fix re-index all files job starting too early

### DIFF
--- a/daemon/nextbox_daemon/jobs.py
+++ b/daemon/nextbox_daemon/jobs.py
@@ -414,7 +414,7 @@ class ReIndexAllFilesJob(BaseJob):
 
     def __init__(self):
         self.nc = Nextcloud()
-        super().__init__(initial_interval=90)
+        super().__init__(initial_interval=900)
 
     def _run(self, cfg, board, kwargs):
         # run once a day


### PR DESCRIPTION
The re-index all files job started too early causing unnecessary errors in log file