### PR TITLE
Docker changes

### DIFF
--- a/daemon/nextbox-compose/Dockerfile
+++ b/daemon/nextbox-compose/Dockerfile
@@ -1,0 +1,10 @@
+FROM --platform=linux/aarch64 nextcloud:27.1.6-apache
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get -y update && \
+    apt-get -y install --no-install-recommends \
+        smbclient
+RUN docker-php-ext-install \
+ mysqli
+

--- a/daemon/nextbox-compose/docker-compose.yml
+++ b/daemon/nextbox-compose/docker-compose.yml
@@ -15,8 +15,9 @@ services:
     restart: always
 
   app:
-    image: nextcloud:27.1.6-apache
-    entrypoint: "/bin/sh -c 'echo \"start delayed by 120secs...\" && sleep 120 && /entrypoint.sh apache2-foreground'"
+    build: .
+    image: nextbox
+    entrypoint: "/bin/sh -c 'echo \"start delayed by 60secs...\" && sleep 60 && /entrypoint.sh apache2-foreground'"
     restart: always
     extra_hosts:
       - dockerhost:172.18.238.1
@@ -39,7 +40,7 @@ services:
       - redis
 
   cron:
-    image: nextcloud:27.1.6-apache
+    image: nextbox
     restart: always
     volumes:
       - nextcloud:/var/www/html
@@ -48,6 +49,7 @@ services:
     depends_on:
       - db
       - redis
+      - app
 
 networks:
   default:

--- a/daemon/nextbox-compose/docker-compose.yml
+++ b/daemon/nextbox-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
   db:
@@ -9,15 +9,25 @@ services:
       - db:/var/lib/mysql
     env_file:
       - /srv/nextbox/docker.env
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "--password=$MYSQL_PASSWORD", "--user=$MYSQL_USER"]
+      interval: 5s
+      timeout: 20s
+      retries: 12
 
   redis:
     image: redis:5.0.11-alpine
     restart: always
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli ping | grep PONG"]
+      interval: 5s
+      timeout: 20s
+      retries: 12
 
   app:
     build: .
     image: nextbox
-    entrypoint: "/bin/sh -c 'echo \"start delayed by 60secs...\" && sleep 60 && /entrypoint.sh apache2-foreground'"
+    entrypoint: "/entrypoint.sh apache2-foreground"
     restart: always
     extra_hosts:
       - dockerhost:172.18.238.1


### PR DESCRIPTION
Adds healthchecks to db and redis so that nextbox actually waits for them to be up instead of blindly waiting 2 min
Changes nextcloud image to be built locally in order to have access to smbclient and php module mysqli
