### PR TITLE
image: change pi-gen version to build bullseye instead of buster

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -3,7 +3,7 @@
 image:
 	git clone https://github.com/RPi-Distro/pi-gen.git gen-image
 	cd gen-image && \
-		git checkout 041b97464c01ac6453e4aab59dc931220237bc16
+		git checkout 1a5baa1d3592e42899d7553bdf00a4cabc364564
 	cp -r image-config/config gen-image
 	cp -r image-config/stage-nextbox gen-image
 	sed -i -e 's/setarch linux32 //g' gen-image/scripts/common


### PR DESCRIPTION
Changes pi-gen commit to build the image off of to be debian bullseye instead of buster

