### PR TITLE
fix event dispatcher api change

### DIFF
--- a/app/nextbox/lib/AppInfo/Application.php
+++ b/app/nextbox/lib/AppInfo/Application.php
@@ -22,7 +22,8 @@ class Application extends App {
         parent::__construct('nextbox', $urlParams);
 
 				$container = $this->getContainer();
-				$dispatcher = \OC::$server->getEventDispatcher();
+				// $dispatcher = \OC::$server->getEventDispatcher();
+				$dispatcher = $container->query(IEventDispatcher::class);
 				$dispatcher->addListener(AddContentSecurityPolicyEvent::class, function (AddContentSecurityPolicyEvent $e) {
 
 					$csp = new ContentSecurityPolicy();

--- a/debian/repos/watch-files-app
+++ b/debian/repos/watch-files-app
@@ -15,3 +15,4 @@ app/nextbox/src/UtilsMixin.js
 app/nextbox/src/main.js
 app/nextbox/src/Overview.vue
 app/nextbox/lib/Controller/PageController.php
+app/nextbox/lib/AppInfo/Application.php


### PR DESCRIPTION
NextCloud 28 dropped the deprecated `symfony/event-dispatcher`, so the NextBox app has to use the new `\OCP\EventDispatcher\IEventDispatcher`.