### PR TITLE
add occ db:add-missing-indices

### DIFF
--- a/daemon/nextbox_daemon/jobs.py
+++ b/daemon/nextbox_daemon/jobs.py
@@ -435,6 +435,31 @@ class ReIndexAllFilesJob(BaseJob):
             return False
 
 
+class AddMissingIndicesJob(BaseJob):
+    name = "AddMissingIndices"
+
+    def __init__(self):
+        self.nc = Nextcloud()
+        super().__init__(initial_interval=900)
+
+    def _run(self, cfg, board, kwargs):
+        # run only once
+        self.interval = None
+
+        # only add missing indices, if nextcloud is installed
+        if not self.nc.is_installed:
+            log.debug("cannot add missing indices - uninitialized nextcloud")
+            self.interval = 15
+            return False
+
+        try:
+            self.nc.run_cmd("db:add-missing-indices")
+        except NextcloudError:
+            log.warning("cannot add missing indices")
+            self.interval = 15
+            return False
+
+
 class PurgeOldDockerImagesJob(BaseJob):
     """
     Job to periodically purge old images using
@@ -554,6 +579,6 @@ ACTIVE_JOBS = [
     LEDJob, FactoryResetJob, BackupRestoreJob, EnableNextBoxAppJob,
     SelfUpdateJob, HardwareStatusUpdateJob,
     TrustedDomainsJob, RenewCertificatesJob, DynDNSUpdateJob,
-    EnableHTTPSJob, ReIndexAllFilesJob,
+    EnableHTTPSJob, ReIndexAllFilesJob, AddMissingIndicesJob,
     PurgeOldDockerImagesJob, OccUpgradeJob, AdminNotification,
 ]


### PR DESCRIPTION
Add automatic `occ db:add-missing-indices` documented [here](https://docs.nextcloud.com/server/latest/admin_manual/configuration_server/occ_command.html#add-missing-indices)
