### PR TITLE
NC 32.0.12

### DIFF
--- a/app/nextbox/src/System.vue
+++ b/app/nextbox/src/System.vue
@@ -185,7 +185,7 @@ export default {
 
 			try {
 				const res = await axios.get(generateUrl('/apps/nextbox/forward/debianVersion'))
-				this.canDebianUpdate = (res.data.data.version === 11)
+				//this.canDebianUpdate = (res.data.data.version === 11)
 			} catch (e) {
 				console.error(e)
 			}

--- a/daemon/nextbox-compose/Dockerfile
+++ b/daemon/nextbox-compose/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/aarch64 nextcloud:32.0.11-apache
+FROM --platform=linux/aarch64 nextcloud:32.0.12-apache
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Update nextcloud to 32.0.12
Disable debian 12 update option for now until remaining migration issues are solved.
This may need frontend version bump.